### PR TITLE
Fix Python 3.6 compatibility

### DIFF
--- a/tkreadonly.py
+++ b/tkreadonly.py
@@ -1,5 +1,9 @@
 try:
-    from idlelib.WidgetRedirector import WidgetRedirector
+    try:
+        from idlelib.WidgetRedirector import WidgetRedirector
+    except ImportError:
+        # Renamed in Python 3.6 (see http://bugs.python.org/issue24225)
+        from idlelib.redirector import WidgetRedirector
 except ImportError:
     import platform
     import sys


### PR DESCRIPTION
This unbreaks Cricket in Python 3.6, because the module has been renamed.

References:
File renamed: https://hg.python.org/cpython/file/6ecd4db71b88/Lib/idlelib/redirector.py
Corresponding CPython issue: http://bugs.python.org/issue24225